### PR TITLE
3. Add template definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ Show step by step how a website is built with [sulu.io](http://sulu.io) from [su
 
 ## Steps
 
-1. [Installation and Basic Setup](https://github.com/alexander-schranz/example-sulu-website/pull/1)
-2. [Frontend Setup](https://github.com/alexander-schranz/example-sulu-website/pull/2)
+1. [Installation and basic setup](https://github.com/alexander-schranz/example-sulu-website/pull/1)
+2. [Frontend setup](https://github.com/alexander-schranz/example-sulu-website/pull/2)
+3. [Add template definitions](https://github.com/alexander-schranz/example-sulu-website/pull/3)
+

--- a/app/Resources/templates/includes/blocks-overview.xml
+++ b/app/Resources/templates/includes/blocks-overview.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <block name="overview" default-type="text" minOccurs="0" maxOccurs="99">
+        <meta>
+            <title lang="de"></title>
+            <title lang="en"></title>
+        </meta>
+
+        <types>
+            <type name="text">
+                <meta>
+                    <title lang="en">Automatically Teaser</title>
+                    <title lang="de">Automatische Teaser</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="teaser" type="smart_content">
+                        <meta>
+                            <title lang="en">Smart Content</title>
+                            <title lang="de">Smart Content</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="text">
+                <meta>
+                    <title lang="en">Manuel Teasers</title>
+                    <title lang="de">Manuelle Teasers</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="teaser" type="teaser_selection">
+                        <meta>
+                            <title lang="en">Teaser Selection</title>
+                            <title lang="de">Teaser Auswahl</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+        </types>
+    </block>
+</properties>

--- a/app/Resources/templates/includes/blocks.xml
+++ b/app/Resources/templates/includes/blocks.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <block name="blocks" default-type="text" minOccurs="0" maxOccurs="99">
+        <meta>
+            <title lang="de"></title>
+            <title lang="en"></title>
+        </meta>
+
+        <types>
+            <type name="text">
+                <meta>
+                    <title lang="en">Text</title>
+                    <title lang="de">Text</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="info">
+                <meta>
+                    <title lang="en">info</title>
+                    <title lang="de">info</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+
+                    <property name="images" type="media_selection">
+                        <meta>
+                            <title lang="en">Images</title>
+                            <title lang="de">Bilder</title>
+                        </meta>
+
+                        <params>
+                            <param name="types" value="image" />
+                            <param name="displayOptions" value="false" />
+                        </params>
+                    </property>
+
+                    <property name="position" type="single_select">
+                        <meta>
+                            <title lang="en">Position</title>
+                            <title lang="de">Position</title>
+                        </meta>
+
+                        <params>
+                            <param name="values" type="collection">
+                                <param name="">
+                                    <meta>
+                                        <title lang="de">keine</title>
+                                        <title lang="en">No</title>
+                                    </meta>
+                                </param>
+
+                                <param name="left">
+                                    <meta>
+                                        <title lang="de">Links</title>
+                                        <title lang="en">Left</title>
+                                    </meta>
+                                </param>
+
+                                <param name="right">
+                                    <meta>
+                                        <title lang="de">Rechts</title>
+                                        <title lang="en">Right</title>
+                                    </meta>
+                                </param>
+                            </param>
+                        </params>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="embed">
+                <meta>
+                    <title lang="en">Embed</title>
+                    <title lang="de">Embed</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+
+                    <property name="code" type="text_area">
+                        <meta>
+                            <title lang="en">Embed Code</title>
+                            <title lang="de">Embed Code</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="gallery">
+                <meta>
+                    <title lang="en">Gallery</title>
+                    <title lang="de">Galerie</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+
+                    <property name="images" type="media_selection">
+                        <meta>
+                            <title lang="en">Images</title>
+                            <title lang="de">Bilder</title>
+                        </meta>
+
+                        <params>
+                            <param name="types" value="image" />
+                        </params>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="download">
+                <meta>
+                    <title lang="en">Download</title>
+                    <title lang="de">Download</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+
+                    <property name="files" type="media_selection">
+                        <meta>
+                            <title lang="en">Medien</title>
+                            <title lang="de">Medien</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+
+            <type name="teaser">
+                <meta>
+                    <title lang="en">Teaser</title>
+                    <title lang="de">Teaser</title>
+                </meta>
+
+                <properties>
+                    <property name="title" type="text_line">
+                        <meta>
+                            <title lang="en">Title</title>
+                            <title lang="de">Titel</title>
+                        </meta>
+
+                        <tag name="sulu.content.sortmode.show"/>
+                    </property>
+
+                    <property name="description" type="text_editor">
+                        <meta>
+                            <title lang="en">Description</title>
+                            <title lang="de">Beschreibung</title>
+                        </meta>
+                    </property>
+                    
+                    <property name="teasers" type="teaser_selection">
+                        <meta>
+                            <title lang="en">Images</title>
+                            <title lang="de">Bilder</title>
+                        </meta>
+                    </property>
+                </properties>
+            </type>
+        </types>
+    </block>
+</properties>

--- a/app/Resources/templates/includes/content.xml
+++ b/app/Resources/templates/includes/content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <property name="description" type="text_editor">
+        <meta>
+            <title lang="en">Description</title>
+            <title lang="de">Beschreibung</title>
+        </meta>
+    </property>
+</properties>

--- a/app/Resources/templates/includes/header.xml
+++ b/app/Resources/templates/includes/header.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <property name="headerImages" type="media_selection">
+        <meta>
+            <title lang="en">Images</title>
+            <title lang="de">Bilder</title>
+        </meta>
+
+        <params>
+            <param name="types" value="image" />
+            <param name="displayOptions" value="false" />
+        </params>
+    </property>
+</properties>

--- a/app/Resources/templates/includes/highlight.xml
+++ b/app/Resources/templates/includes/highlight.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+    <property name="title" type="text_line" mandatory="true">
+        <meta>
+            <title lang="en">Title</title>
+            <title lang="de">Titel</title>
+        </meta>
+
+        <params>
+            <param name="headline" value="true"/>
+        </params>
+
+        <tag name="sulu.rlp.part"/>
+    </property>
+
+    <property name="url" type="resource_locator" mandatory="true">
+        <meta>
+            <title lang="en">Resourcelocator</title>
+            <title lang="de">Adresse</title>
+        </meta>
+
+        <tag name="sulu.rlp"/>
+    </property>
+</properties>

--- a/app/Resources/templates/pages/default.xml
+++ b/app/Resources/templates/pages/default.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <template xmlns="http://schemas.sulu.io/template/template"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
 
     <key>default</key>
@@ -22,6 +23,7 @@
                         <title lang="en">Title</title>
                         <title lang="de">Titel</title>
                     </meta>
+
                     <params>
                         <param name="headline" value="true"/>
                     </params>
@@ -40,11 +42,32 @@
             </properties>
         </section>
 
-        <property name="article" type="text_editor">
+        <section name="header">
             <meta>
-                <title lang="en">Article</title>
-                <title lang="de">Artikel</title>
+                <title lang="en">Header</title>
+                <title lang="de">Header</title>
             </meta>
-        </property>
+
+            <xi:include href="../includes/header.xml"/>
+        </section>
+
+        <section name="content">
+            <meta>
+                <title lang="en">Content</title>
+                <title lang="de">Inhalt</title>
+            </meta>
+
+
+            <xi:include href="../includes/content.xml"/>
+        </section>
+
+        <section name="block">
+            <meta>
+                <title lang="en">Blocks</title>
+                <title lang="de">Inhaltsblöcke</title>
+            </meta>
+
+            <xi:include href="../includes/blocks.xml"/>
+        </section>
     </properties>
 </template>

--- a/app/Resources/templates/pages/homepage.xml
+++ b/app/Resources/templates/pages/homepage.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <template xmlns="http://schemas.sulu.io/template/template"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
 
     <key>homepage</key>
@@ -16,29 +17,7 @@
 
     <properties>
         <section name="highlight">
-            <properties>
-                <property name="title" type="text_line" mandatory="true">
-                    <meta>
-                        <title lang="en">Title</title>
-                        <title lang="de">Titel</title>
-                    </meta>
-
-                    <params>
-                        <param name="headline" value="true"/>
-                    </params>
-
-                    <tag name="sulu.rlp.part"/>
-                </property>
-
-                <property name="url" type="resource_locator" mandatory="true">
-                    <meta>
-                        <title lang="en">Resourcelocator</title>
-                        <title lang="de">Adresse</title>
-                    </meta>
-
-                    <tag name="sulu.rlp"/>
-                </property>
-            </properties>
+            <xi:include href="../includes/highlight.xml"/>
         </section>
 
         <section name="header">

--- a/app/Resources/templates/pages/homepage.xml
+++ b/app/Resources/templates/pages/homepage.xml
@@ -22,6 +22,7 @@
                         <title lang="en">Title</title>
                         <title lang="de">Titel</title>
                     </meta>
+
                     <params>
                         <param name="headline" value="true"/>
                     </params>
@@ -40,11 +41,20 @@
             </properties>
         </section>
 
-        <property name="article" type="text_editor">
+        <section name="header">
             <meta>
-                <title lang="en">Article</title>
-                <title lang="de">Artikel</title>
+                <title lang="en">Header</title>
+                <title lang="de">Header</title>
             </meta>
-        </property>
+
+            <properties>
+                <property name="headerTeaser" type="teaser_selection">
+                    <meta>
+                        <title lang="en">Teaser</title>
+                        <title lang="de">Teaser</title>
+                    </meta>
+                </property>
+            </properties>
+        </section>
     </properties>
 </template>

--- a/app/Resources/templates/pages/overview.xml
+++ b/app/Resources/templates/pages/overview.xml
@@ -4,15 +4,15 @@
           xmlns:xi="http://www.w3.org/2001/XInclude"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
 
-    <key>default</key>
+    <key>overview</key>
 
-    <view>AppBundle:website:templates/pages/default</view>
+    <view>AppBundle:website:templates/pages/overview</view>
     <controller>SuluWebsiteBundle:Default:index</controller>
     <cacheLifetime>144000</cacheLifetime>
 
     <meta>
-        <title lang="en">Default</title>
-        <title lang="de">Standard</title>
+        <title lang="en">Overview</title>
+        <title lang="de">Übersicht</title>
     </meta>
 
     <properties>
@@ -29,23 +29,13 @@
             <xi:include href="../includes/header.xml"/>
         </section>
 
-        <section name="content">
+        <section name="overview">
             <meta>
-                <title lang="en">Content</title>
-                <title lang="de">Inhalt</title>
+                <title lang="en">Overview</title>
+                <title lang="de">Übersicht</title>
             </meta>
 
-
-            <xi:include href="../includes/content.xml"/>
-        </section>
-
-        <section name="block">
-            <meta>
-                <title lang="en">Blocks</title>
-                <title lang="de">Inhaltsblöcke</title>
-            </meta>
-
-            <xi:include href="../includes/blocks.xml"/>
+            <xi:include href="../includes/blocks-overview.xml"/>
         </section>
     </properties>
 </template>

--- a/src/AppBundle/Resources/views/website/templates/pages/default.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/default.html.twig
@@ -2,8 +2,4 @@
 
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
-
-    <div property="article">
-        {{ content.article|raw }}
-    </div>
 {% endblock %}

--- a/src/AppBundle/Resources/views/website/templates/pages/homepage.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/homepage.html.twig
@@ -2,8 +2,4 @@
 
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
-
-    <div property="article">
-        {{ content.article|raw }}
-    </div>
 {% endblock %}

--- a/src/AppBundle/Resources/views/website/templates/pages/overview.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/overview.html.twig
@@ -1,0 +1,5 @@
+{% extends "AppBundle:website:master.html.twig" %}
+
+{% block content %}
+    <h1 property="title">{{ content.title }}</h1>
+{% endblock %}


### PR DESCRIPTION
# Add template definitions

You can define multiple templates for your project. A basic website has mostly 3 types of Templates:

 - `homepage`: special template for the website homepage
 - `default`: a basic template for relevant content
 - `overview`: a template link to other content pages using mostly

This template files can be found in `app/Resources/templates/pages`.

## Defining the homepage template

The homepage template exist in the default installation and can be found as `homepage.xml` in the pages template folder. Based on your design you can now add multiple properties. Mostly for the usability of the content manager you add new sections to the root properties tag e.g.:

```xml
<service name="content">
    <meta>
        <title lang="en">Content</title>
        <title lang="de">Inhalt</title>
    </meta>

    <properties>
         <!-- add properties here -->
    </properties>
</section>
``` 

You can now add properties to your template. A full list of all available content types can be found in the [Content Type Reference](http://docs.sulu.io/en/latest/reference/content-types/)

## Add a new template

To add a new template you need to create a new xml file in the pages template folder. The easy way copy an exist remove all properties you don't need, except the highlight section with title and url property. The template `key` need to be the same as the new filename you also should change the templates view for rendering e.g.:

```xml
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <key>overview</key><!-- need to be the same as template filename -->

    <view>AppBundle:website:templates/pages/overview</view><!-- the template file -->
    <controller>SuluWebsiteBundle:Default:index</controller>
    <cacheLifetime>144000</cacheLifetime>

    <meta>
        <title lang="en">Default</title>
        <title lang="de">Standard</title>
    </meta>

    <properties>
        <section name="highlight">
            <properties>
                <property name="title" type="text_line" mandatory="true">
                    <meta>
                        <title lang="en">Title</title>
                        <title lang="de">Titel</title>
                    </meta>
                    <params>
                        <param name="headline" value="true"/>
                    </params>

                    <tag name="sulu.rlp.part"/>
                </property>

                <property name="url" type="resource_locator" mandatory="true">
                    <meta>
                        <title lang="en">Resourcelocator</title>
                        <title lang="de">Adresse</title>
                    </meta>

                    <tag name="sulu.rlp"/>
                </property>
            </properties>
        </section>

        <!-- adding more section and properties here -->
    </properties>
</template>
```

That the new template is available in the backend also the view .html.twig template need to be created in the example it need to be created in `src/AppBundle/Resources/views/website/templates/pages/` as `overview.html.twig` and can look like this:

```twig
{% extends "AppBundle:website:master.html.twig" %}

{% block content %}
    <h1 property="title">{{ content.title }}</h1>
{% endblock %}
```

If your new template is not visible check the following:

 - The backend cache is cleared in the correct environment e.g. run `bin/adminconsole cache:clear -e dev`
 - The template filename is the same as your template key e.g. `overview.xml` need `<key>overview</key>`
 - The view file exist: e.g.:  `<view>AppBundle:website:templates/pages/overview</view>` needs `src/AppBundle/Resources/views/website/templates/pages/overview.html.twig`
 - The bundle containing the view is registered in the `app/AbstractKernel.php` and not only in one Kernel.

## Create reusable xml definitions with xinclude

To avoid duplicated definitions of the templates you can use the `xinclude` feature to create snippets of definitions you can reuse. As an example every template need the highlight section which we can add as xinclude file. For this we need to move the highlight section properties into an own `highlight.xml` file in `app/Resources/templates/includes/` which will look like:

```xml
<?xml version="1.0" ?>
<properties xmlns="http://schemas.sulu.io/template/template"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
    <property name="title" type="text_line" mandatory="true">
        <meta>
            <title lang="en">Title</title>
            <title lang="de">Titel</title>
        </meta>

        <params>
            <param name="headline" value="true"/>
        </params>

        <tag name="sulu.rlp.part"/>
    </property>

    <property name="url" type="resource_locator" mandatory="true">
        <meta>
            <title lang="en">Resourcelocator</title>
            <title lang="de">Adresse</title>
        </meta>

        <tag name="sulu.rlp"/>
    </property>
</properties>
```

To use this in the pages template definition we need to add the `xInclude` definition (`xmlns:xi="http://www.w3.org/2001/XInclude"`) to our template and include it then with the `xi:include` tag e.g.:

```xml
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns:xi="http://www.w3.org/2001/XInclude"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <!-- ... -->

    <properties>
        <section name="highlight">
            <xi:include href="../includes/highlight.xml"/>
        </section>

    <!-- ... -->
    </properties>
</template>
```

## Using the block content type to create a flexible default template

The [block content type](http://docs.sulu.io/en/latest/reference/content-types/block.html) make it possible to combine different groups of content types. The block content type is also the correct way how to add `images` between different text. The xml definition can look like the following code snippet, it makes possible to position the images over the media_selection displayOption up to 9 different positions. Mostly  it will be image before the text (`top`), image floated left (`left`), image floated right (`right`) and image after the text (`bottom`). Its possible to implement this in the way you need it in the twig template file:

```xml
<block name="blocks" default-type="text" minOccurs="0">
    <meta>
        <title lang="de">Inhalte</title>
        <title lang="en">Content</title>
    </meta>

    <types>
        <type name="text">
            <meta>
                <title lang="de">Text</title>
                <title lang="en">Text </title>
            </meta>

            <properties>
                <property name="images" type="media_selection" colspan="3">
                    <meta>
                        <title lang="de">Bilder</title>
                        <title lang="en">Images</title>
                    </meta>

                    <params>
                        <param name="type" value="image"/>
                        <param name="displayOptions" type="collection">
                            <param name="leftTop" value="false"/>
                            <param name="top" value="true"/>
                            <param name="rightTop" value="false"/>
                            <param name="left" value="true"/>
                            <param name="middle" value="false"/>
                            <param name="right" value="true"/>
                            <param name="leftBottom" value="false"/>
                            <param name="bottom" value="true"/>
                            <param name="rightBottom" value="false"/>
                        </param>
                    </params>
                </property>

                <property name="article" type="text_editor" colspan="9">
                    <meta>
                        <title lang="de">Artikel</title>
                        <title lang="en">Article</title>
                    </meta>
                </property>
            </properties>
        </type>
    </types>
</block>
``` 

## Adding a new type to the block content type

Its possible to add another type to the block content type so you can combine them. As an example we can add an `embed` type that the content manager can add different embed codes: 

```xml
<block name="blocks" default-type="embed" minOccurs="0">
    <types>
        <!-- ... -->

        <type name="embed">
            <meta>
                <title lang="en">Embed</title>
                <title lang="de">Embed</title>
            </meta>
        
            <properties>
                <property name="title" type="text_line">
                    <meta>
                        <title lang="en">Title</title>
                        <title lang="de">Titel</title>
                    </meta>
        
                    <tag name="sulu.content.sortmode.show"/>
                </property>
        
                <property name="description" type="text_editor">
                    <meta>
                        <title lang="en">Description</title>
                        <title lang="de">Beschreibung</title>
                    </meta>
                </property>
        
                <property name="code" type="text_area">
                    <meta>
                        <title lang="en">Embed Code</title>
                        <title lang="de">Embed Code</title>
                    </meta>
                </property>
            </properties>
        </type>
    </types>
</block>
``` 

