### PR TITLE
4. Add template rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Show step by step how a website is built with [sulu.io](http://sulu.io) from [su
 1. [Installation and basic setup](https://github.com/alexander-schranz/example-sulu-website/pull/1)
 2. [Frontend setup](https://github.com/alexander-schranz/example-sulu-website/pull/2)
 3. [Add template definitions](https://github.com/alexander-schranz/example-sulu-website/pull/3)
+4. [Add Template rendering](https://github.com/alexander-schran/example-sulu-website/pull/4)
 

--- a/app/Resources/templates/includes/blocks-overview.xml
+++ b/app/Resources/templates/includes/blocks-overview.xml
@@ -10,10 +10,10 @@
         </meta>
 
         <types>
-            <type name="text">
+            <type name="automatic">
                 <meta>
-                    <title lang="en">Automatically Teaser</title>
-                    <title lang="de">Automatische Teaser</title>
+                    <title lang="en">Automatically Teasers</title>
+                    <title lang="de">Automatische Teasers</title>
                 </meta>
 
                 <properties>
@@ -26,18 +26,28 @@
                         <tag name="sulu.content.sortmode.show"/>
                     </property>
 
-                    <property name="teaser" type="smart_content">
+                    <property name="teasers" type="smart_content">
                         <meta>
                             <title lang="en">Smart Content</title>
                             <title lang="de">Smart Content</title>
                         </meta>
+
+                        <params>
+                            <param name="properties" type="collection">
+                                <param name="title" value="title" />
+                                <param name="description" value="description" />
+                                <param name="headerImages" value="headerImages" />
+                                <param name="excerptImages" value="excerpt.images"/>
+                                <param name="excerptDescription" value="excerpt.description" />
+                            </param>
+                        </params>
                     </property>
                 </properties>
             </type>
 
-            <type name="text">
+            <type name="manual">
                 <meta>
-                    <title lang="en">Manuel Teasers</title>
+                    <title lang="en">Manual Teasers</title>
                     <title lang="de">Manuelle Teasers</title>
                 </meta>
 
@@ -51,7 +61,7 @@
                         <tag name="sulu.content.sortmode.show"/>
                     </property>
 
-                    <property name="teaser" type="teaser_selection">
+                    <property name="teasers" type="teaser_selection">
                         <meta>
                             <title lang="en">Teaser Selection</title>
                             <title lang="de">Teaser Auswahl</title>

--- a/app/Resources/templates/includes/blocks.xml
+++ b/app/Resources/templates/includes/blocks.xml
@@ -37,8 +37,8 @@
 
             <type name="info">
                 <meta>
-                    <title lang="en">info</title>
-                    <title lang="de">info</title>
+                    <title lang="en">Info</title>
+                    <title lang="de">Info</title>
                 </meta>
 
                 <properties>
@@ -127,7 +127,7 @@
                         </meta>
                     </property>
 
-                    <property name="code" type="text_area">
+                    <property name="embed" type="text_area">
                         <meta>
                             <title lang="en">Embed Code</title>
                             <title lang="de">Embed Code</title>
@@ -167,6 +167,7 @@
 
                         <params>
                             <param name="types" value="image" />
+                            <param name="displayOptions" value="false"/>
                         </params>
                     </property>
                 </properties>
@@ -229,8 +230,8 @@
                     
                     <property name="teasers" type="teaser_selection">
                         <meta>
-                            <title lang="en">Images</title>
-                            <title lang="de">Bilder</title>
+                            <title lang="en">Teasers</title>
+                            <title lang="de">Teasers</title>
                         </meta>
                     </property>
                 </properties>

--- a/app/Resources/templates/pages/default.xml
+++ b/app/Resources/templates/pages/default.xml
@@ -35,7 +35,6 @@
                 <title lang="de">Inhalt</title>
             </meta>
 
-
             <xi:include href="../includes/content.xml"/>
         </section>
 

--- a/app/Resources/templates/pages/homepage.xml
+++ b/app/Resources/templates/pages/homepage.xml
@@ -27,7 +27,7 @@
             </meta>
 
             <properties>
-                <property name="headerTeaser" type="teaser_selection">
+                <property name="headerTeasers" type="teaser_selection">
                     <meta>
                         <title lang="en">Teaser</title>
                         <title lang="de">Teaser</title>

--- a/app/config/image-formats.xml
+++ b/app/config/image-formats.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<formats xmlns="http://schemas.sulu.io/media/formats"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">
+
+    <format key="1440x">
+        <scale x="1440"/>
+    </format>
+
+    <format key="720x">
+        <scale x="720"/>
+    </format>
+
+    <format key="300x150">
+        <scale x="300" y="150"/>
+    </format>
+
+    <format key="100x50">
+        <scale x="100" y="50"/>
+    </format>
+</formats>

--- a/src/AppBundle/Resources/views/website/blocks/header.html.twig
+++ b/src/AppBundle/Resources/views/website/blocks/header.html.twig
@@ -1,0 +1,12 @@
+<header class="header">
+    {% if content.headerImages|length %}
+        {% for image in content.headerImages %}
+            {% include "AppBundle:website:includes/image.html.twig" with {
+                image: image,
+                class: 'header__image',
+                format: '1440x',
+                mobileFormat: '720x'
+            } only %}
+        {% endfor %}
+    {% endif %}
+</header>

--- a/src/AppBundle/Resources/views/website/includes/block-types/download.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/download.html.twig
@@ -1,0 +1,15 @@
+{% extends "AppBundle:website:includes/block-types/text.html.twig" %}
+
+{% block content %}
+    {% if content.files|length %}
+        <ul property="files" class="file">
+            {% for file in content.files %}
+                <li class="file__item file__item--{{ file.type.name }}">
+                    <a href="{{ asset(file.url) }}" class="file__link">
+                        {{ file.title }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/block-types/embed.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/embed.html.twig
@@ -1,0 +1,9 @@
+{% extends "AppBundle:website:includes/block-types/text.html.twig" %}
+
+{% block content %}
+    {% if content.embed %}
+        <div property="embed" class="embed">
+            {{ content.embed|raw }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/block-types/gallery.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/gallery.html.twig
@@ -1,0 +1,19 @@
+{% extends "AppBundle:website:includes/block-types/text.html.twig" %}
+
+{% block content %}
+    {% if content.images|length %}
+        <div property="images" class="gallery">
+            {% for image in content.images %}
+                <div class="gallery__item">
+                    <a href="{{ image.thumbnails['1440x'] }}">
+                        {% include "AppBundle:website:includes/image.html.twig" with {
+                            image: image,
+                            class: 'gallery__image',
+                            format: '100x50'
+                        } only %}
+                    </a>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/block-types/info.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/info.html.twig
@@ -1,0 +1,17 @@
+<aside class="info {{- content.position ? ' info--' ~ content.position : '' }}">
+    {% block title %}
+        {% if content.title %}
+            <h2 property="title" class="info__title">
+                {{ content.title }}
+            </h2>
+        {% endif %}
+    {% endblock %}
+
+    {% block descripiton %}
+        {% if content.description %}
+            <div property="description" class="info_description">
+                {{ content.description|raw }}
+            </div>
+        {% endif %}
+    {% endblock %}
+</aside>

--- a/src/AppBundle/Resources/views/website/includes/block-types/teaser.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/teaser.html.twig
@@ -1,0 +1,29 @@
+{% extends "AppBundle:website:includes/block-types/text.html.twig" %}
+
+{% block content %}
+    {% if content.teasers|length %}
+        <div property="teaser" class="teaser">
+            {% for teaser in content.teasers %}
+                <a href="{{ sulu_content_path(teaser.url) }}" class="teaser__item">
+                    <h3 class="teaser__title">
+                        {{ teaser.title }}
+                    </h3>
+
+                    {% if teaser.mediaId %}
+                        {% include "AppBundle:website:includes/image.html.twig" with {
+                            image: sulu_resolve_media(teaser.mediaId, app.request.locale),
+                            class: 'teaser__image',
+                            format: '300x150'
+                        } only %}
+                    {% endif %}
+
+                    {% if teaser.description %}
+                        <div class="teaser__description">
+                            {{ teaser.description|raw }}
+                        </div>
+                    {% endif %}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/block-types/text.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/block-types/text.html.twig
@@ -1,0 +1,19 @@
+<section class="content">
+    {% block title %}
+        {% if content.title %}
+            <h2 property="title" class="content__title">
+                {{ content.title }}
+            </h2>
+        {% endif %}
+    {% endblock %}
+
+    {% block description %}
+        {% if content.description %}
+            <div property="description" class="content__description">
+                {{ content.description|raw }}
+            </div>
+        {% endif %}
+    {% endblock %}
+
+    {% block content %}{% endblock %}
+</section>

--- a/src/AppBundle/Resources/views/website/includes/blocks.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/blocks.html.twig
@@ -1,0 +1,8 @@
+<div property="blocks" typeof="collection" class="blocks">
+    {% for block in content.blocks %}
+        {% include 'AppBundle:website:includes/block-types/' ~ block.type ~ '.html.twig' with {
+            content: block,
+            view: view.blocks[loop.index0]
+        } only %}
+    {% endfor %}
+</div>

--- a/src/AppBundle/Resources/views/website/includes/image.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/image.html.twig
@@ -1,0 +1,11 @@
+<picture>
+    {% if mobileFormat|default -%}
+        <source srcset="{{ image.thumbnails[mobileFormat] }}" media="(max-width: 720px)">
+    {%- endif %}
+
+    <img src="{{ image.thumbnails[format] }}" {# Src -#}
+         alt="{{ image.title }}" {# Alt -#}
+         {% if class|default -%} class="{{ class }}"{%- endif %} {# Class -#}
+         title="{{ image.description|default(image.title) }}"  {#- Title -#}
+    >
+</picture>

--- a/src/AppBundle/Resources/views/website/includes/overview-types/automatic.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/overview-types/automatic.html.twig
@@ -1,0 +1,22 @@
+{% extends "AppBundle:website:includes/overview-types/base.html.twig" %}
+
+{% block teaser %}
+    {% set description = teaser.excerptDescription|default(teaser.description) %}
+    {% set image = teaser.excerptImages[0]|default(teaser.headerImages[0]|default) %}
+
+    <h3 class="teaser__title">{{ teaser.title }}</h3>
+
+    {% if image %}
+        {% include "AppBundle:website:includes/image.html.twig" with {
+            image: image,
+            class: 'teaser__image',
+            format: '300x150'
+        } only %}
+    {% endif %}
+
+    {% if description %}
+        <div class="teaser__description">
+            {{ description|raw }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/overview-types/base.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/overview-types/base.html.twig
@@ -1,0 +1,18 @@
+<section class="content">
+    {% if content.title %}
+        <h2 property="title" class="content__title">
+            {{ content.title }}
+        </h2>
+    {% endif %}
+
+    {% if content.teasers|length %}
+        <div property="teasers" typeof="collection">
+            {% for teaser in content.teasers %}
+                <a href="{{ sulu_content_path(teaser.url) }}" class="teaser__item">
+                    {% block teaser %}{% endblock %}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
+</section>
+

--- a/src/AppBundle/Resources/views/website/includes/overview-types/manual.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/overview-types/manual.html.twig
@@ -1,0 +1,23 @@
+{% extends "AppBundle:website:includes/overview-types/base.html.twig" %}
+
+{% block teaser %}
+    <h3 class="teaser__title">{{ teaser.title }}</h3>
+
+    {% if teaser.mediaId %}
+        {% set image = sulu_resolve_media(teaser.mediaId, app.request.locale) %}
+
+        {% if image %}
+            {% include "AppBundle:website:includes/image.html.twig" with {
+                image: image,
+                class: 'teaser__image',
+                format: '300x150'
+            } only %}
+        {% endif %}
+    {% endif %}
+
+    {% if teaser.description %}
+        <div class="teaser__description">
+            {{ teaser.description|raw }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/website/includes/overview.html.twig
+++ b/src/AppBundle/Resources/views/website/includes/overview.html.twig
@@ -1,0 +1,8 @@
+<div property="overview" typeof="collection" class="blocks">
+    {% for block in content.overview %}
+        {% include 'AppBundle:website:includes/overview-types/' ~ block.type ~ '.html.twig' with {
+            content: block,
+            view: view.overview[loop.index0]
+        } only %}
+    {% endfor %}
+</div>

--- a/src/AppBundle/Resources/views/website/templates/pages/default.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/default.html.twig
@@ -2,4 +2,10 @@
 
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
+
+    <div property="description">
+        {{ content.description|raw }}
+    </div>
+
+    {% include "AppBundle:website:includes/blocks.html.twig" %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/website/templates/pages/homepage.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/homepage.html.twig
@@ -1,5 +1,26 @@
 {% extends "AppBundle:website:master.html.twig" %}
 
+{% block header %}
+    <header class="header">
+        {% if content.headerTeasers|length %}
+            {% for teaser in content.headerTeasers %}
+                {% set image = sulu_resolve_media(teaser.mediaId, app.request.locale) %}
+
+                <a href="{{ sulu_content_path(teaser.url) }}"
+                   class="header__item"
+                   title="{{ teaser.title }}">
+                    {% include "AppBundle:website:includes/image.html.twig" with {
+                        image: image,
+                        class: 'header__image',
+                        format: '1440x',
+                        mobileFormat: '720x'
+                    } only %}
+                </a>
+            {% endfor %}
+        {% endif %}
+    </header>
+{% endblock %}
+
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
 {% endblock %}

--- a/src/AppBundle/Resources/views/website/templates/pages/overview.html.twig
+++ b/src/AppBundle/Resources/views/website/templates/pages/overview.html.twig
@@ -2,4 +2,6 @@
 
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
+
+    {% include "AppBundle:website:includes/overview.html.twig" %}
 {% endblock %}


### PR DESCRIPTION
# Add template rendering

## Defining image formats

To define different image formats for a sulu website a `image-formats.xml` need to be created inside the `app/config/` folder. There you can define multiple image formats which can used inside the template.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<formats xmlns="http://schemas.sulu.io/media/formats"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">

    <format key="1440x1000">
        <meta>
            <title lang="en">Header Image</title>
        </meta>
        <scale x="1440" y="1000"/>
    </format>
</formats>
```

The format `key` is how you can access the format in your code. The format `title` is used to in the backend drop down in the cropping area mostly its recommended to set as title where the format is used e.g. Header image. The `scale` tag defines how the image will be cropped and resized. There are different image manipulations possible.

```xml
<!-- max. 1440px width, height is dynamic -->
<format key="1440x">
    <scale x="1440"/>
</format>

<!-- max. 720x height, width is dynamic -->
<format key="x720">
    <scale y="720"/>
</format>

<!-- max. 500x width, max. 500x height, ratio is fixed 1x1 (image will get cropped) -->
<format key="500x500">
    <scale x="500" y="500"/>
</format>

<!-- max. 500x width, max. 500x height, ratio is dynamic -->
<format key="500x500">
    <scale x="500" y="500" mode="inset"/>
</format>
```

**Using image format**

```twig
{% for image in content.images %}
    <img src="{{ image.thumbnails['1440x'] }}" alt="Test">
{% endfor %}
```

## Live Preview properties

As mentioned in the docs the [live preview need to implement](http://docs.sulu.io/en/latest/cookbook/live-preview.html) so all changes the content manager does are automatically seen in the live preview. 

For simple text properties its just adding the propertyName in its tag where the property is rendered:

```twig
<h1 property="title">{{ content.title }}</h1>
```

For other have a look at the[docs](http://docs.sulu.io/en/latest/cookbook/live-preview.html) 

## Rendering blocks

For the blocks of the default template you can simple create foreach type an own twig template and render them iterate over all blocks an dynamically include the correct type:

```twig
<div property="blocks" typeof="collection" class="blocks">
    {% for block in content.blocks %}
        {% include 'AppBundle:website:includes/block-types/' ~ block.type ~ '.html.twig' with {
            content: block,
            view: view.blocks[loop.index0]
        } only %}
    {% endfor %}
</div>
```

## Rendering Smart Content and Teaser

### TODO